### PR TITLE
Bug Fix: Null over empty Array

### DIFF
--- a/handlers/playlistsHandler.go
+++ b/handlers/playlistsHandler.go
@@ -53,7 +53,7 @@ func CreatePlaylist(c *gin.Context) {
 		Title:         playlist.Title,
 		Status:        playlist.Status,
 		DueDate:       playlist.DueDate,
-		PlaylistItems: playlist.PlaylistItems,
+		PlaylistItems: []*models.PlaylistItem{},
 	}
 
 	c.JSON(http.StatusCreated, gin.H{
@@ -134,7 +134,7 @@ func ShowPlaylist(c *gin.Context) {
 		Title:         playlist.Title,
 		Status:        playlist.Status,
 		DueDate:       playlist.DueDate,
-		PlaylistItems: playlist.PlaylistItems,
+		PlaylistItems: []*models.PlaylistItem{},
 	}
 
 	c.JSON(http.StatusOK, gin.H{
@@ -144,7 +144,7 @@ func ShowPlaylist(c *gin.Context) {
 	})
 }
 
-func UpdatePlaylist(c *gin.Context)  {
+func UpdatePlaylist(c *gin.Context) {
 	var input CreatePlaylistInput
 
 	if bindErr := c.BindJSON(&input); bindErr != nil {
@@ -165,8 +165,8 @@ func UpdatePlaylist(c *gin.Context)  {
 	}
 
 	_, err := models.PlaylistConnect.Model(&playlist).
-																   Where("id = ?", playlistID).
-																   Update(&playlist)
+		Where("id = ?", playlistID).
+		Update(&playlist)
 
 	if err != nil {
 		panic(err)
@@ -178,7 +178,7 @@ func UpdatePlaylist(c *gin.Context)  {
 		Title:         playlist.Title,
 		Status:        playlist.Status,
 		DueDate:       playlist.DueDate,
-		PlaylistItems: playlist.PlaylistItems,
+		PlaylistItems: []*models.PlaylistItem{},
 	}
 
 	c.JSON(http.StatusOK, gin.H{

--- a/models/playlist.go
+++ b/models/playlist.go
@@ -14,7 +14,7 @@ type Playlist struct {
 	Title         string          `json:"title,omitempty"`
 	Status        string          `json:"status,omitempty"`
 	DueDate       string          `json:"due_date,omitempty"`
-	PlaylistItems []*PlaylistItem `json:"items"`
+	PlaylistItems []*PlaylistItem `json:"playlist_items"`
 	CreatedAt     time.Time       `json:"created_at"`
 	UpdatedAt     time.Time       `json:"updated_at"`
 }


### PR DESCRIPTION
# Description :: User Story

## Type of change

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Breaking Change

## Notes
I managed a work around for displaying an empty array. I basically called the empty list of playlist_items until we can figure out how to get the relationship to work. That said, this is not a permanent fix but will at least solve the issue related to returning arrays or null. It is super important to note that Go will _always_ initialize an empty value to its _nil_ state. In the case of an array, it's null. In this event, the marshaling of json had to do with it as well. So I had to find a way to make an empty array, _look_ empty. 

## RSpec results

```
Test Coverage Here
```
